### PR TITLE
Handle munge key perms and ownership on worker node

### DIFF
--- a/vagrant/bootstrap-worker.sh
+++ b/vagrant/bootstrap-worker.sh
@@ -38,6 +38,8 @@ yum groups install -q -y 'Development Tools'
 
 yum install -q -y munge munge-libs munge-devel
 cp /usr/local/share/Kive/vagrant/munge-test.key /etc/munge/munge.key
+chown munge:munge /etc/munge/munge.key
+chmod 400 /etc/munge/munge.key
 systemctl enable munge
 systemctl start munge
 


### PR DESCRIPTION
The Munge key needs to be mode 400 and owned by the `munge` user. This step was added to the Head node provisioning script, but not the worker provisioning script. This PR fixes that.