### PR TITLE
Update the PostGreSQL repository url

### DIFF
--- a/vagrant/setuplib.sh
+++ b/vagrant/setuplib.sh
@@ -9,7 +9,7 @@ function setuplib::postgres {
     pushd /root
 
     echo "========== Installing PostgreSQL =========="
-    sudo rpm -Uvh https://yum.postgresql.org/10/redhat/rhel-7-x86_64/pgdg-centos10-10-2.noarch.rpm
+    sudo rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
     yum install -q -y postgresql10-server postgresql10-contrib
     /usr/pgsql-10/bin/postgresql-10-setup initdb
 


### PR DESCRIPTION
This commit updates the URL of the RPM that installs the PostGreSQL YUM
repository. Note that this isn't the URL for the RPM for PostGreSQL itself, but
for a metadata package which lets us do `yum install postgresql10-server`.

This update is necessary because the URL which it replaces stopped working.

The new URL is the one recommended by
https://www.postgresql.org/download/linux/redhat/