### PR TITLE
Replace removed singularity command

### DIFF
--- a/kive/container/models.py
+++ b/kive/container/models.py
@@ -339,7 +339,7 @@ class Container(AccessControl):
         :return:
         """
         try:
-            check_output([SINGULARITY_COMMAND, 'check', file_path], stderr=STDOUT)
+            check_output([SINGULARITY_COMMAND, 'inspect', file_path], stderr=STDOUT)
         except CalledProcessError as ex:
             logger.warning('Invalid container file:\n%s', ex.output)
             raise ValidationError(cls.DEFAULT_ERROR_MESSAGES['invalid_singularity_container'],


### PR DESCRIPTION
This commit replaces use of the `singularity check` command with `singularity
inspect`. The `check` command was removed in Singularity 3.0 (though this
wasn't mentioned in the project's change log).

Strictly speaking, the `inspect` command does less than the original `check`
command--the former merely parses the image and display its metadata whereas
the latter also applies security heuristics. However, it would appear that Kive
was using the `check` command to validate that an uploaded file was in fact a
Singularity image, and not depending on `check`'s other features.