### PR TITLE
WIP Avoid stale static files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 env:
   global:
     - KIVE_DB_USER=postgres
+    - KIVE_STATIC_ROOT=/tmp/kive_test_static_root
 before_install:
     - sudo apt-get install -y -q dh-autoreconf build-essential libarchive-dev squashfs-tools
     - nvm install 12.13.1
@@ -28,6 +29,7 @@ script:
   - set -e
   - npm run test:travis
   - cd kive
+  - python manage.py collectstatic --no-input
   - coverage run -m pytest --ds kive.settings_test_pg
   - cd ../api
   - coverage run --source=kiveapi -m pytest

--- a/kive/container/templates/container/batch_form.html
+++ b/kive/container/templates/container/batch_form.html
@@ -1,16 +1,17 @@
 <!-- Django template -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Container Run Batch{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/permissions.js"></script>
-    <script src="/static/portal/ajaxsearchfilter.js"></script>
-    <script src="/static/portal/helptext.js"></script>
-    <script src="/static/container/ContainerRunTable.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/permissions.js' %}"></script>
+    <script src="{% static 'portal/ajaxsearchfilter.js' %}"></script>
+    <script src="{% static 'portal/helptext.js' %}"></script>
+    <script src="{% static 'container/ContainerRunTable.js' %}"></script>
     <script type="text/javascript">
 
     $(function(){
@@ -31,8 +32,8 @@
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/portal/permissions.css"/>
-    <link rel="stylesheet" href="/static/portal/search.css"/>
+    <link rel="stylesheet" href="{% static 'portal/permissions.css' %}"/>
+    <link rel="stylesheet" href="{% static 'portal/search.css' %}"/>
 {% endblock %}
 
 {% block widget_media %}

--- a/kive/container/templates/container/container_content.html
+++ b/kive/container/templates/container/container_content.html
@@ -2,20 +2,21 @@
 <!-- Display contents of Methods as a HTML table -->
 
 {% extends "portal/base.html" %}
+{% load static %} 
 
 {% block title %}Pipeline{% endblock %}
 
 {% block javascript %}
     <!-- Do not remove - Accumulator still uses jQuery as a global. -->
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
 {% endblock %}
 
 {% block stylesheets %}
     <style>
         #canvas{}
     </style>
-    <link rel="stylesheet" href="/static/container/drydock.css"/>
+    <link rel="stylesheet" href="{% static 'container/drydock.css' %}"/>
 {% endblock %}
 
 {% block widget_media %}
@@ -75,6 +76,6 @@
         {% include 'container/content_output_dialog.tpl.html' with dlg_id="id_output_ctrl" %}
 
     </div>
-    <script src="/static/portal/container_content.bundle.js"></script>
+    <script src="{% static 'portal/container_content.bundle.js' %}"></script>
 
 {% endblock %}

--- a/kive/container/templates/container/container_form.html
+++ b/kive/container/templates/container/container_form.html
@@ -1,16 +1,17 @@
 <!-- Django template -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Container{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/permissions.js"></script>
-    <script src="/static/portal/ajaxsearchfilter.js"></script>
-    <script src="/static/portal/helptext.js"></script>
-    <script src="/static/container/ContainerAppTable.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/permissions.js' %}"></script>
+    <script src="{% static 'portal/ajaxsearchfilter.js' %}"></script>
+    <script src="{% static 'portal/helptext.js' %}"></script>
+    <script src="{% static 'container/ContainerAppTable.js' %}"></script>
     <script type="text/javascript">
 
     $(function(){
@@ -30,8 +31,8 @@
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/portal/permissions.css"/>
-    <link rel="stylesheet" href="/static/portal/search.css"/>
+    <link rel="stylesheet" href="{% static 'portal/permissions.css' %}"/>
+    <link rel="stylesheet" href="{% static 'portal/search.css' %}"/>
 {% endblock %}
 
 {% block widget_media %}

--- a/kive/container/templates/container/containerapp_form.html
+++ b/kive/container/templates/container/containerapp_form.html
@@ -1,16 +1,17 @@
 <!-- Django template -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Container App{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/permissions.js"></script>
-    <script src="/static/portal/ajaxsearchfilter.js"></script>
-    <script src="/static/portal/helptext.js"></script>
-    <script src="/static/container/ContainerRunTable.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/permissions.js' %}"></script>
+    <script src="{% static 'portal/ajaxsearchfilter.js' %}"></script>
+    <script src="{% static 'portal/helptext.js' %}"></script>
+    <script src="{% static 'container/ContainerRunTable.js' %}"></script>
     <script type="text/javascript">
 
     $(function(){
@@ -31,8 +32,8 @@
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/portal/permissions.css"/>
-    <link rel="stylesheet" href="/static/portal/search.css"/>
+    <link rel="stylesheet" href="{% static 'portal/permissions.css' %}"/>
+    <link rel="stylesheet" href="{% static 'portal/search.css' %}"/>
 {% endblock %}
 
 {% block widget_media %}

--- a/kive/container/templates/container/containerchoice_list.html
+++ b/kive/container/templates/container/containerchoice_list.html
@@ -2,16 +2,17 @@
 <!-- Display container families -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Container Analysis{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/permissions.js"></script>
-    <script src="/static/container/ContainerChoiceTable.js"></script>
-    <script src="/static/portal/ajaxsearchfilter.js"></script>
-    <script src="/static/portal/helptext.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/permissions.js' %}"></script>
+    <script src="{% static 'container/ContainerChoiceTable.js' %}"></script>
+    <script src="{% static 'portal/ajaxsearchfilter.js' %}"></script>
+    <script src="{% static 'portal/helptext.js' %}"></script>
 
     <script type="text/javascript">
 
@@ -30,8 +31,8 @@
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/portal/permissions.css"/>
-    <link rel="stylesheet" href="/static/portal/search.css"/>
+    <link rel="stylesheet" href="{% static 'portal/permissions.css' %}"/>
+    <link rel="stylesheet" href="{% static 'portal/search.css' %}"/>
 {% endblock %}
 
 {% block content %}

--- a/kive/container/templates/container/containerfamily_form.html
+++ b/kive/container/templates/container/containerfamily_form.html
@@ -1,16 +1,17 @@
 <!-- Django template -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Container family{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/permissions.js"></script>
-    <script src="/static/portal/ajaxsearchfilter.js"></script>
-    <script src="/static/portal/helptext.js"></script>
-    <script src="/static/container/ContainerTable.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/permissions.js' %}"></script>
+    <script src="{% static 'portal/ajaxsearchfilter.js' %}"></script>
+    <script src="{% static 'portal/helptext.js' %}"></script>
+    <script src="{% static 'container/ContainerTable.js' %}"></script>
     <script type="text/javascript">
 
     $(function(){
@@ -30,8 +31,8 @@
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/portal/permissions.css"/>
-    <link rel="stylesheet" href="/static/portal/search.css"/>
+    <link rel="stylesheet" href="{% static 'portal/permissions.css' %}"/>
+    <link rel="stylesheet" href="{% static 'portal/search.css' %}"/>
 {% endblock %}
 
 {% block widget_media %}

--- a/kive/container/templates/container/containerfamily_list.html
+++ b/kive/container/templates/container/containerfamily_list.html
@@ -2,16 +2,17 @@
 <!-- Display container families -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Container Families{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/permissions.js"></script>
-    <script src="/static/container/ContainerFamilyTable.js"></script>
-    <script src="/static/portal/ajaxsearchfilter.js"></script>
-    <script src="/static/portal/helptext.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/permissions.js' %}"></script>
+    <script src="{% static 'container/ContainerFamilyTable.js' %}"></script>
+    <script src="{% static 'portal/ajaxsearchfilter.js' %}"></script>
+    <script src="{% static 'portal/helptext.js' %}"></script>
 
     <script type="text/javascript">
 
@@ -30,8 +31,8 @@
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/portal/permissions.css"/>
-    <link rel="stylesheet" href="/static/portal/search.css"/>
+    <link rel="stylesheet" href="{% static 'portal/permissions.css' %}"/>
+    <link rel="stylesheet" href="{% static 'portal/search.css' %}"/>
 {% endblock %}
 
 {% block content %}

--- a/kive/container/templates/container/containerinput_list.html
+++ b/kive/container/templates/container/containerinput_list.html
@@ -1,24 +1,25 @@
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Analysis{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/moment.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/permissions.js"></script>
-    <script src="/static/container/choose_inputs.js"></script>
-    <script src="/static/container/choose_multi_inputs.js"></script>
-    <script src="/static/portal/ajaxsearchfilter.js"></script>
-    <script src="/static/portal/helptext.js"></script>
-    <script src="/static/container/jq_color_anim.min.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/moment.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/permissions.js' %}"></script>
+    <script src="{% static 'container/choose_inputs.js' %}"></script>
+    <script src="{% static 'container/choose_multi_inputs.js' %}"></script>
+    <script src="{% static 'portal/ajaxsearchfilter.js' %}"></script>
+    <script src="{% static 'portal/helptext.js' %}"></script>
+    <script src="{% static 'container/jq_color_anim.min.js' %}"></script>
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/container/sandbox.css"/>
-    <link rel="stylesheet" href="/static/container/choose_inputs.css"/>
-    <link rel="stylesheet" href="/static/portal/search.css"/>
-    <link rel="stylesheet" href="/static/portal/permissions.css"/>
+    <link rel="stylesheet" href="{% static 'container/sandbox.css' %}"/>
+    <link rel="stylesheet" href="{% static 'container/choose_inputs.css' %}"/>
+    <link rel="stylesheet" href="{% static 'portal/search.css' %}"/>
+    <link rel="stylesheet" href="{% static 'portal/permissions.css' %}"/>
 {% endblock %}
 
 {% block widget_media %}

--- a/kive/container/templates/container/containerlog_detail.html
+++ b/kive/container/templates/container/containerlog_detail.html
@@ -1,17 +1,18 @@
 <!-- Django template -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Container Log{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/helptext.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/helptext.js' %}"></script>
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/librarian/dataset_view.css"/>
+    <link rel="stylesheet" href="{% static 'librarian/dataset_view.css' %}"/>
 {% endblock %}
 
 {% block widget_media %}

--- a/kive/container/templates/container/containerrun_form.html
+++ b/kive/container/templates/container/containerrun_form.html
@@ -1,24 +1,25 @@
 <!-- Django template -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Container Run{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/permissions.js"></script>
-    <script src="/static/portal/ajaxsearchfilter.js"></script>
-    <script src="/static/portal/helptext.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/permissions.js' %}"></script>
+    <script src="{% static 'portal/ajaxsearchfilter.js' %}"></script>
+    <script src="{% static 'portal/helptext.js' %}"></script>
     <script>
     var is_owner = {{ is_owner|lower }},
         is_admin = {{ is_user_admin|lower }};
     </script>
-    <script src="/static/portal/edit_details.js"></script>
+    <script src="{% static 'portal/edit_details.js' %}"></script>
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/portal/permissions.css"/>
+    <link rel="stylesheet" href="{% static 'portal/permissions.css' %}"/>
 {% endblock %}
 
 {% block widget_media %}

--- a/kive/container/templates/container/containerrun_list.html
+++ b/kive/container/templates/container/containerrun_list.html
@@ -2,16 +2,17 @@
 <!-- Display container families -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Container Runs{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/permissions.js"></script>
-    <script src="/static/container/ContainerRunTable.js"></script>
-    <script src="/static/portal/ajaxsearchfilter.js"></script>
-    <script src="/static/portal/helptext.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/permissions.js' %}"></script>
+    <script src="{% static 'container/ContainerRunTable.js' %}"></script>
+    <script src="{% static 'portal/ajaxsearchfilter.js' %}"></script>
+    <script src="{% static 'portal/helptext.js' %}"></script>
 
     <script type="text/javascript">
 
@@ -35,8 +36,8 @@
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/portal/permissions.css"/>
-    <link rel="stylesheet" href="/static/portal/search.css"/>
+    <link rel="stylesheet" href="{% static 'portal/permissions.css' %}"/>
+    <link rel="stylesheet" href="{% static 'portal/search.css' %}"/>
 {% endblock %}
 
 {% block content %}

--- a/kive/container/templates/container/content_view_dialog.tpl.html
+++ b/kive/container/templates/container/content_view_dialog.tpl.html
@@ -1,3 +1,5 @@
+{% load static %}
+
 <div id="{{ dlg_id }}" class="ctrl_menu">
     <h3>View Options</h3>
 
@@ -10,10 +12,10 @@
 
     <label>Align selected nodes:</label>
     <div class="form-inline-opts align-btn-grp">
-        <img src="/static/container/img/dim_x_icon.png" class="image-button align-btn" data-axis="x">
-        <img src="/static/container/img/iso_x_icon.png" class="image-button align-btn" data-axis="iso_x">
-        <img src="/static/container/img/iso_y_icon.png" class="image-button align-btn" data-axis="iso_y">
-        <img src="/static/container/img/iso_z_icon.png" class="image-button align-btn" data-axis="y">
+        <img src="{% static 'container/img/dim_x_icon.png' %}" class="image-button align-btn" data-axis="x">
+        <img src="{% static 'container/img/iso_x_icon.png' %}" class="image-button align-btn" data-axis="iso_x">
+        <img src="{% static 'container/img/iso_y_icon.png' %}" class="image-button align-btn" data-axis="iso_y">
+        <img src="{% static 'container/img/iso_z_icon.png' %}" class="image-button align-btn" data-axis="y">
     </div>
 
     <button id="id_revert">Revert</button>

--- a/kive/kive/settings.py
+++ b/kive/kive/settings.py
@@ -118,6 +118,10 @@ STATICFILES_FINDERS = (
     # 'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
+# Add hashes to the names of static-files (to enable long cache times and 
+# avoid stale JS/CSS).
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+
 # Make this unique, and don't share it with anybody. Call this to generate a
 # new one, then set environment variable:
 # ./manage.py shell -c "import django; print(django.core.management.utils.get_random_secret_key())"

--- a/kive/librarian/templates/librarian/dataset_lookup.html
+++ b/kive/librarian/templates/librarian/dataset_lookup.html
@@ -4,12 +4,13 @@
 {% extends "portal/base.html" %}
 
 {% load filters %}
+{% load static %}
 
 {% block title %}Pipeline Lookup{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
 {% endblock %}
 
 {% block content %}

--- a/kive/librarian/templates/librarian/dataset_view.html
+++ b/kive/librarian/templates/librarian/dataset_view.html
@@ -3,12 +3,13 @@
 {% extends "portal/base.html" %}
 
 {% load filters %}
+{% load static %}
 
 {% block title %}Datasets{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
     <script>
     var is_owner = {{ is_owner|lower }},
         is_admin = {{ is_admin|lower }},
@@ -22,13 +23,13 @@
         });
     });
     </script>
-    <script src="/static/portal/edit_details.js"></script>
+    <script src="{% static 'portal/edit_details.js' %}"></script>
     {% block data_specific_js %}
     {% endblock %}
 {% endblock %}
 
 {% block stylesheets %}
-<link rel="stylesheet" href="/static/librarian/dataset_view.css">
+<link rel="stylesheet" href="{% static 'librarian/dataset_view.css' %}">
 {% endblock %}
 
 {% block widget_media %}

--- a/kive/librarian/templates/librarian/datasets.html
+++ b/kive/librarian/templates/librarian/datasets.html
@@ -2,17 +2,18 @@
 <!-- Display contents of Methods as a HTML table -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% load filters %}
 
 {% block title %}Datasets{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/portal/permissions.js"></script>
-    <script src="/static/librarian/DatasetsTable.js"></script>
-    <script src="/static/portal/ajaxsearchfilter.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'portal/permissions.js' %}"></script>
+    <script src="{% static 'librarian/DatasetsTable.js' %}"></script>
+    <script src="{% static 'portal/ajaxsearchfilter.js' %}"></script>
     <script type="text/javascript">
     $(function(){
         var is_user_admin = {{ is_user_admin|lower }};
@@ -49,8 +50,8 @@
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/portal/permissions.css">
-    <link rel="stylesheet" href="/static/portal/search.css">
+    <link rel="stylesheet" href="{% static 'portal/permissions.css' %}">
+    <link rel="stylesheet" href="{% static 'portal/search.css' %}">
 {% endblock %}
 
 {% block content %}

--- a/kive/librarian/templates/librarian/datasets_add_archive.html
+++ b/kive/librarian/templates/librarian/datasets_add_archive.html
@@ -2,16 +2,17 @@
 <!-- Allow user to choose an archive file -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Datasets{% endblock %}
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/librarian/datasets_add.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'librarian/datasets_add.js' %}"></script>
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/librarian/datasets_add_archive.css"/>
+    <link rel="stylesheet" href="{% static 'librarian/datasets_add_archive.css' %}"/>
 {% endblock %}
 
 {% block widget_media %}
@@ -87,7 +88,7 @@
 
 <div class="errorStrip errortext">{{ bulkAddDatasetForm.non_field_errors }}</div>
 <div id="loading" class="loading_container">
-    <p><img src="/static/container/img/preload.gif" class="loading_img"/>Please Wait...</p>
+    <p><img src="{% static 'container/img/preload.gif' %}" class="loading_img"/>Please Wait...</p>
 </div>
 </form>
 {% endblock %}

--- a/kive/librarian/templates/librarian/datasets_add_bulk.html
+++ b/kive/librarian/templates/librarian/datasets_add_bulk.html
@@ -2,16 +2,17 @@
 <!-- Display contents of Methods as a HTML table -->
 
 {% extends "portal/base.html" %}
+{% load static %}
 
 {% block title %}Datasets{% endblock %}
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script src="/static/librarian/datasets_add.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script src="{% static 'librarian/datasets_add.js' %}"></script>
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/librarian/datasets_add_archive.css"/>
+    <link rel="stylesheet" href="{% static 'librarian/datasets_add_archive.css' %}"/>
 {% endblock %}
 
 {% block widget_media %}
@@ -86,7 +87,7 @@
 
 <div class="errorStrip errortext">{{ bulkAddDatasetForm.non_field_errors }}</div>
 <div id="loading" class="loading_container">
-    <p><img src="/static/container/img/preload.gif" class="loading_img"/>Please Wait...</p>
+    <p><img src="{% static 'container/img/preload.gif' %}" class="loading_img"/>Please Wait...</p>
 </div>
 
 </form>

--- a/kive/librarian/templates/librarian/datasets_bulk.html
+++ b/kive/librarian/templates/librarian/datasets_bulk.html
@@ -2,16 +2,17 @@
 <!-- View recently added bulk datasets -->
 
 {% extends "portal/base.html" %}
+{%load static %}
 
 {% block title %}Added Datasets{% endblock %}
 
 {% block javascript %}
-    <script src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
+    <script src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/librarian/datasets_bulk.css"/>
+    <link rel="stylesheet" href="{% static 'librarian/datasets_bulk.css' %}"/>
 {% endblock %}
 
 
@@ -75,9 +76,9 @@
                         Will be handy if lots of large files -->
                         <td class="status_cell">
                             {% if dataset_form.status == "1" %}
-                            <img class="loading_img" src="/static/portal/img/fail.png" width="20" height="auto">
+                            <img class="loading_img" src="{% static 'portal/img/fail.png' %}" width="20" height="auto">
                             {% else %}
-                            <img class="loading_img" src="/static/portal/img/success.png" width="20" height="auto">
+                            <img class="loading_img" src="{% static 'portal/img/success.png' %}" width="20" height="auto">
                             {% endif %}
                         </td>
                         <td class="errortext">{{ dataset_form.non_field_errors }}</td>

--- a/kive/librarian/templates/librarian/lookup.html
+++ b/kive/librarian/templates/librarian/lookup.html
@@ -4,18 +4,19 @@
 {% extends "portal/base.html" %}
 
 {% load filters %}
+{% load static %}
 
 {% block title %}Pipeline Lookup{% endblock %}
 
 {% block javascript %}
-    <script type="text/javascript" src="/static/portal/jquery-2.0.3.min.js"></script>
-    <script src="/static/portal/noxss.js"></script>
-    <script type="text/javascript" src="/static/librarian/md5.js"></script>
-    <script type="text/javascript" src="/static/librarian/lookup.js"></script>
+    <script type="text/javascript" src="{% static 'portal/jquery-2.0.3.min.js' %}"></script>
+    <script src="{% static 'portal/noxss.js' %}"></script>
+    <script type="text/javascript" src="{% static 'librarian/md5.js' %}"></script>
+    <script type="text/javascript" src="{% static 'librarian/lookup.js' %}"></script>
 {% endblock %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" href="/static/librarian/lookup.css"/>
+    <link rel="stylesheet" href="{% static 'librarian/lookup.css' %}"/>
 {% endblock %}
 
 {% block content %}

--- a/kive/portal/templates/portal/base.html
+++ b/kive/portal/templates/portal/base.html
@@ -8,10 +8,8 @@
 {% block widget_media %}{% endblock %}
 {% block stylesheets %}{% endblock %}
 <link rel="stylesheet" href="{% static 'portal/style.css' %}" media="screen">
-
-{% load staticfiles %}
-
 <link rel="shortcut icon" href="{% static 'portal/favicon.png' %}">
+
 </head>
 <body>
 

--- a/kive/portal/templates/portal/base.html
+++ b/kive/portal/templates/portal/base.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html><!-- Django template -->
 <html>
 <head>
@@ -6,7 +7,7 @@
 {% block javascript %}{% endblock %}
 {% block widget_media %}{% endblock %}
 {% block stylesheets %}{% endblock %}
-<link rel="stylesheet" href="/static/portal/style.css" media="screen">
+<link rel="stylesheet" href="{% static 'portal/style.css' %}" media="screen">
 
 {% load staticfiles %}
 

--- a/kive/portal/templates/portal/dev.html
+++ b/kive/portal/templates/portal/dev.html
@@ -1,10 +1,11 @@
 <!-- Django template -->
-
 {% extends "portal/base.html" %}
+{% load static %}
+
 {% block title %}kive for Developers{% endblock %}
 
 {% block stylesheets %}
-<link rel="stylesheet" href="/static/portal/portal.css">
+<link rel="stylesheet" href="{% static 'portal/portal.css' %}">
 {% endblock %}
 
 {% block content %}
@@ -12,7 +13,7 @@
 <a href="/" rel="prev">Return to homepage</a>
 
 
-<img class="header-icon" src="/static/portal/dev_icon.png">
+<img class="header-icon" src="{% static 'portal/dev_icon.png' %}">
 <h2>Developers</h2>
 
 

--- a/kive/portal/templates/portal/index.html
+++ b/kive/portal/templates/portal/index.html
@@ -1,17 +1,18 @@
 <!-- Django template -->
-
 {% extends "portal/base.html" %}
+{% load static %}
+
 {% block title %}kive{% endblock %}
 
 {% block stylesheets %}
-<link rel="stylesheet" href="/static/portal/portal.css">
+<link rel="stylesheet" href="{% static 'portal/portal.css' %}">
 {% endblock %}
 
 {% block content %}
 <nav><ul>
     <li>
         <a href="/usr.html">
-        <img class="menu-icon" src="/static/portal/user_icon.png">
+        <img class="menu-icon" src="{% static 'portal/user_icon.png' %}">
         <h4 class="menu-item">Users</h4>
         <p class="menu-description">Upload data sets and process data using containers.</p>
         </a>
@@ -19,7 +20,7 @@
     {% if is_developer %}
     <li>
         <a href="/dev.html">
-        <img class="menu-icon" src="/static/portal/dev_icon.png">
+        <img class="menu-icon" src="{% static 'portal/dev_icon.png' %}">
         <h4 class="menu-item">Developers</h4>
         <p class="menu-description">Add or modify containers.</p>
         </a>
@@ -28,7 +29,7 @@
     {% if user.is_staff %}
     <li>
         <a href="/admin/">
-        <img class="menu-icon" src="/static/portal/admin_icon.png">
+        <img class="menu-icon" src="{% static 'portal/admin_icon.png' %}">
         <h4 class="menu-item">Administrators</h4>
         <p class="menu-description">Add, remove, or modify users and groups</p>
         </a>

--- a/kive/portal/templates/portal/usr.html
+++ b/kive/portal/templates/portal/usr.html
@@ -1,16 +1,17 @@
 <!-- Django template -->
-
 {% extends "portal/base.html" %}
+{% load static %}
+
 {% block title %}kive for Users{% endblock %}
 
 {% block stylesheets %}
-<link rel="stylesheet" href="/static/portal/portal.css">
+<link rel="stylesheet" href="{% static 'portal/portal.css' %}">
 {% endblock %}
 
 {% block content %}
 <a href="/" rel="prev">Return to homepage</a>
 
-<img class="header-icon" src="/static/portal/user_icon.png">
+<img class="header-icon" src="{% static 'portal/user_icon.png' %}">
 <h2>Users</h2>
 
 

--- a/kive/portal/templates/rest_framework/api.html
+++ b/kive/portal/templates/rest_framework/api.html
@@ -1,8 +1,9 @@
 {% extends "rest_framework/base.html" %}
+{% load static %}
 
 {% block style %}
 {{ block.super }}
-<link rel="shortcut icon" type="image/png" href="/static/portal/favicon.png" />
+<link rel="shortcut icon" type="image/png" href="{% static 'portal/favicon.png' %}" />
 {% endblock %}
 
 {# This customizes the Django REST Framework's browsable API. #}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
-django-mock-queries==2.1.3
+django-mock-queries==2.1.5
 pytest==5.3.5
 pytest-django==3.7.0


### PR DESCRIPTION
This merge request has two commits. One adopts the static file handling subsystem in Kive's HTML templates. The other changes Kive's settings to append MD5 hashes to static files (including files loaded in CSS).

See the commit messages for more details.

Fixes #442 