### PR TITLE
Catch empty zipfiles

### DIFF
--- a/kive/container/forms.py
+++ b/kive/container/forms.py
@@ -59,7 +59,12 @@ class ContainerForm(ContainerUpdateForm):
         self.cleaned_data = super(ContainerForm, self).clean()
 
         # Check the file extension of the file.
-        the_file = self.cleaned_data["file"]
+        the_file = self.cleaned_data.get("file")
+        if the_file is None:
+            raise ValidationError(
+                Container.DEFAULT_ERROR_MESSAGES["invalid_archive"],
+                code="invalid_archive",
+            )
         upload_name = getattr(the_file, 'name', 'container.simg')
         upload_base, upload_ext = os.path.splitext(upload_name)
         upload_lower = upload_name.lower()

--- a/kive/container/models.py
+++ b/kive/container/models.py
@@ -355,6 +355,11 @@ class Container(AccessControl):
         Confirm that the file is of the correct type.
         :return:
         """
+        if not self.file:
+            raise ValidationError(
+                self.DEFAULT_ERROR_MESSAGES["invalid_archive"],
+                code="invalid_archive",
+            )
         if self.file_type == Container.SIMG:
             if self.parent is not None:
                 raise ValidationError(self.DEFAULT_ERROR_MESSAGES["singularity_cannot_have_parent"],

--- a/kive/container/tests.py
+++ b/kive/container/tests.py
@@ -3847,6 +3847,12 @@ echo Hello World
         self.assertTrue(form.is_valid())
         self.assertTrue(form.instance.singularity_validated)
 
+    def test_uploaded_empty(self):
+        empty_file = BytesIO(b"")
+        form = ContainerForm(self.form_data, files={"file": empty_file})
+        self.assertFalse(form.is_valid())
+        self.assertTrue(form.has_error(NON_FIELD_ERRORS, code="invalid_archive"))
+
     def test_temp_file_invalid(self):
         file_data = b'garbage content'
 


### PR DESCRIPTION
This commit adds logic to catch empty Zipfiles when they're submitted as
containers. This case requires some special handling as `FieldField.file` that
gets passed to the container validation code doesn't exist, which causes
exceptions in Django's file validation code. The solution is to catch this case
before the brittler validation code runs and return early.

Fixes #773