### PR TITLE
Cleanup Python 2 artifacts

### DIFF
--- a/api/kiveapi/dataset.py
+++ b/api/kiveapi/dataset.py
@@ -5,7 +5,7 @@ object, and some support methods.
 from . import KiveMalformedDataException
 
 
-class Dataset(object):
+class Dataset:
     """
     A wrapper class for Kive's Dataset object
     """

--- a/api/kiveapi/endpoint_manager.py
+++ b/api/kiveapi/endpoint_manager.py
@@ -1,7 +1,7 @@
 import re
 
 
-class EndpointManager(object):
+class EndpointManager:
     def __init__(self, session):
         self.session = session
 
@@ -9,7 +9,7 @@ class EndpointManager(object):
         return SessionContext(self.session, name)
 
 
-class SessionContext(object):
+class SessionContext:
     def __init__(self, session, name):
         self.session = session
         self.prefix = '/api/{}/'.format(name)

--- a/kive/FixtureFiles/demo/CodeResources/aln2counts.py
+++ b/kive/FixtureFiles/demo/CodeResources/aln2counts.py
@@ -64,7 +64,7 @@ logger = miseq_logging.init_logging_console_only(logging.DEBUG)
 MAX_CUTOFF = 'MAX'
 
 
-class SequenceReport(object):
+class SequenceReport:
     """ Hold the data for several reports related to a sample's genetic sequence.
 
     To use a report object, read a group of aligned reads that mapped to a
@@ -519,7 +519,7 @@ class SequenceReport(object):
                                      self.reports[coordinate_name])
 
 
-class SeedAmino(object):
+class SeedAmino:
     """
     Records the frequencies of amino acids at a given position of the
     aligned reads as determined by the consensus sequence.
@@ -564,7 +564,7 @@ class SeedAmino(object):
         return '-' if not consensus else consensus[0][0]
 
 
-class SeedNucleotide(object):
+class SeedNucleotide:
     """
     Records the frequencies of nucleotides at a given position of the
     aligned reads as determined by the consensus sequence.
@@ -634,7 +634,7 @@ class SeedNucleotide(object):
         return consensus
 
 
-class ReportAmino(object):
+class ReportAmino:
     def __init__(self, seed_amino, position):
         """ Create a new instance.
 
@@ -647,7 +647,7 @@ class ReportAmino(object):
         return 'ReportAmino({!r}, {})'.format(self.seed_amino, self.position)
 
 
-class InsertionWriter(object):
+class InsertionWriter:
     def __init__(self, insert_file):
         """ Initialize a writer object.
 

--- a/kive/FixtureFiles/demo/CodeResources/externals.py
+++ b/kive/FixtureFiles/demo/CodeResources/externals.py
@@ -4,7 +4,7 @@ import sys
 import re
 
 
-class AssetWrapper(object):
+class AssetWrapper:
     """ Wraps a packaged asset, and finds its path. """
     def __init__(self, path):
         app_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))

--- a/kive/FixtureFiles/demo/CodeResources/project_config.py
+++ b/kive/FixtureFiles/demo/CodeResources/project_config.py
@@ -2,7 +2,7 @@ import json
 import os
 
 
-class ProjectConfig(object):
+class ProjectConfig:
     @classmethod
     def search(cls, project_paths):
         projects = None

--- a/kive/FixtureFiles/demo/CodeResources/pssm_lib.py
+++ b/kive/FixtureFiles/demo/CodeResources/pssm_lib.py
@@ -13,7 +13,7 @@ import gotoh
 from micall.utils.translation import translate
 
 
-class Pssm(object):
+class Pssm:
     def __init__(self, std='g2p', path_to_lookup=None, path_to_matrix=None):
         if std == 'pssm':
             self.std_v3 = 'CTRPNNNTRKGIHIGPGRAFYATGEIIGDIRQAHC'

--- a/kive/FixtureFiles/demo/CodeResources/remap.py
+++ b/kive/FixtureFiles/demo/CodeResources/remap.py
@@ -809,7 +809,7 @@ def map_to_reference(fastq1,
     return unmapped_count
 
 
-class MixedReferenceSplitter(object):
+class MixedReferenceSplitter:
     def __init__(self):
         self.splits = {}
 

--- a/kive/container/forms.py
+++ b/kive/container/forms.py
@@ -13,14 +13,14 @@ logger = logging.getLogger(__name__)
 
 
 class BatchForm(PermissionsForm):
-    class Meta(object):
+    class Meta:
         model = Batch
         fields = ['name', 'description', 'permissions']
         widgets = dict(description=forms.Textarea(attrs=dict(cols=50, rows=10)))
 
 
 class ContainerFamilyForm(PermissionsForm):
-    class Meta(object):
+    class Meta:
         model = ContainerFamily
         fields = ['name', 'git', 'description', 'permissions']
         widgets = dict(description=forms.Textarea(attrs=dict(cols=50, rows=10)))
@@ -32,7 +32,7 @@ class ContainerUpdateForm(PermissionsForm):
         queryset=Container.objects.filter(file_type=Container.SIMG),
         required=False)
 
-    class Meta(object):
+    class Meta:
         model = Container
         fields = ['parent', 'tag', 'description', 'permissions']
         widgets = dict(description=forms.Textarea(attrs=dict(cols=50, rows=10)))
@@ -119,14 +119,14 @@ class ContainerAppForm(forms.ModelForm):
                   'prefixes and suffixes for different kinds of arguments: '
                   '--optional, folder/, and --optional_folder/.')
 
-    class Meta(object):
+    class Meta:
         model = ContainerApp
         exclude = ['container']
         widgets = dict(description=forms.Textarea(attrs=dict(cols=50, rows=10)))
 
 
 class ContainerRunForm(PermissionsForm):
-    class Meta(object):
+    class Meta:
         model = ContainerRun
         fields = ['name', 'description', 'permissions']
         widgets = dict(description=forms.Textarea(attrs=dict(cols=50, rows=10)))

--- a/kive/container/management/commands/count_queries.py
+++ b/kive/container/management/commands/count_queries.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from collections import Counter
 from datetime import datetime
 import re

--- a/kive/container/management/commands/purge.py
+++ b/kive/container/management/commands/purge.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import errno
 import logging
 import os

--- a/kive/container/management/commands/runcontainer.py
+++ b/kive/container/management/commands/runcontainer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import errno
 import logging
 import os

--- a/kive/container/management/commands/runcontainer.py
+++ b/kive/container/management/commands/runcontainer.py
@@ -358,7 +358,7 @@ class Command(BaseCommand):
         return final_return_code
 
 
-class DependencyFilter(object):
+class DependencyFilter:
     def __init__(self, archive_directory, step):
         self.archive_directory = archive_directory
         # The dependencies list is only used when converting old pipelines.

--- a/kive/container/management/commands/set_run_md5s.py
+++ b/kive/container/management/commands/set_run_md5s.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from django.core.management.base import BaseCommand
 
 from container.models import ContainerRun

--- a/kive/container/models.py
+++ b/kive/container/models.py
@@ -108,7 +108,7 @@ class ContainerFamily(AccessControl):
         blank=True)
     containers = None  # Filled in later from child table.
 
-    class Meta(object):
+    class Meta:
         ordering = ['name']
 
     def __str__(self):
@@ -143,7 +143,7 @@ class ChildNotConfigured(Exception):
     pass
 
 
-class PipelineCompletionStatus(object):
+class PipelineCompletionStatus:
     def __init__(self, pipeline):
         self.has_inputs = False
         self.has_steps = False
@@ -708,7 +708,7 @@ class Container(AccessControl):
             yield os.path.join(relative_root, file_name)
 
 
-class ZipHandler(object):
+class ZipHandler:
     MemberInfo = namedtuple('MemberInfo', 'name original')
 
     def __init__(self, fileobj=None, mode='r', archive=None):
@@ -902,7 +902,7 @@ class ContainerArgument(models.Model):
 
     objects = None  # Filled in later by Django.
 
-    class Meta(object):
+    class Meta:
         ordering = ('app_id', 'type', 'position', 'name')
 
     def __repr__(self):
@@ -944,7 +944,7 @@ class Batch(AccessControl):
 
     runs = None  # Filled in later by Django.
 
-    class Meta(object):
+    class Meta:
         ordering = ('-id',)
 
     def __str__(self):
@@ -1059,7 +1059,7 @@ class ContainerRun(Stopwatch, AccessControl):
         default=False,
         help_text="True if a warning was logged because the Slurm job failed.")
 
-    class Meta(object):
+    class Meta:
         ordering = ('-submit_time',)
 
     def __str__(self):
@@ -1413,7 +1413,7 @@ class ContainerDataset(models.Model):
 
     objects = None  # Filled in later by Django.
 
-    class Meta(object):
+    class Meta:
         ordering = ('run',
                     'argument__type',
                     'argument__position',

--- a/kive/container/models.py
+++ b/kive/container/models.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import errno
 import hashlib
 import json

--- a/kive/container/serializers.py
+++ b/kive/container/serializers.py
@@ -135,7 +135,7 @@ class ContainerArgumentSerializer(serializers.ModelSerializer):
         lookup_field='pk',
         queryset=ContainerApp.objects.all())
 
-    class Meta(object):
+    class Meta:
         model = ContainerArgument
         fields = ('id',
                   'url',

--- a/kive/container/tests_deffile.py
+++ b/kive/container/tests_deffile.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 """Test module for deffile.py"""
 
-from __future__ import unicode_literals
 from django.test import TestCase
 
 import container.deffile as deffile

--- a/kive/container/views.py
+++ b/kive/container/views.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import json
 import os
 

--- a/kive/kive/ajax.py
+++ b/kive/kive/ajax.py
@@ -90,7 +90,7 @@ class IsDeveloperOrGrantedReadOnly(IsGrantedReadOnly):
         return developer_check(request.user) and request.method in ("POST", "PATCH")
 
 
-class GrantedModelMixin(object):
+class GrantedModelMixin:
     """ Filter instances that the user has been granted access to.
 
     Mix this in with a view set to add a query parameter:
@@ -120,7 +120,7 @@ class GrantedModelMixin(object):
                                             queryset=queryset)
 
 
-class RedactModelMixin(object):
+class RedactModelMixin:
     """ Redacts a model instance and build a redaction plan.
 
     Mix this in with a view set to provide default behaviour for data redaction.

--- a/kive/kive/ratelimitingfilter.py
+++ b/kive/kive/ratelimitingfilter.py
@@ -105,7 +105,7 @@ class RateLimitingFilter(logging.Filter):
         return self._auto_buckets[record.msg]
 
 
-class TokenBucket(object):
+class TokenBucket:
     """
     An implementation of the Token Bucket algorithm.
     """

--- a/kive/kive/tests.py
+++ b/kive/kive/tests.py
@@ -23,7 +23,7 @@ from constants import users
 from metadata.models import kive_user, KiveUser
 
 
-class DuckRequest(object):
+class DuckRequest:
     """ A fake request used to test serializers. """
     def __init__(self, user=None):
         self.user = user or kive_user()
@@ -70,7 +70,7 @@ class ViewMockTestCase(TestCase, object):
         return client
 
 
-class BaseTestCases(object):
+class BaseTestCases:
     """ A class to hide our base classes so they won't be executed as tests.
     """
     def __init__(self):

--- a/kive/librarian/management/commands/convert_external_datasets.py
+++ b/kive/librarian/management/commands/convert_external_datasets.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import re
 from argparse import ArgumentDefaultsHelpFormatter
 from glob import glob

--- a/kive/librarian/management/commands/find_orphans.py
+++ b/kive/librarian/management/commands/find_orphans.py
@@ -1,6 +1,4 @@
 #! /opt/venv_kive/bin/python
-from __future__ import print_function
-
 import logging
 
 import psycopg2

--- a/kive/librarian/models.py
+++ b/kive/librarian/models.py
@@ -4,8 +4,6 @@ librarian.models
 Shipyard data models pertaining to the lookup of the past: ExecRecord,
 Dataset, etc.
 """
-from __future__ import unicode_literals
-
 import csv
 import logging
 import os

--- a/kive/librarian/serializers.py
+++ b/kive/librarian/serializers.py
@@ -9,7 +9,7 @@ from kive.serializers import AccessControlSerializer
 
 
 class ExternalFileDirectorySerializer(serializers.ModelSerializer):
-    class Meta(object):
+    class Meta:
         model = ExternalFileDirectory
         fields = (
             'pk',
@@ -27,7 +27,7 @@ class ExternalFileDirectoryListFilesSerializer(ExternalFileDirectorySerializer):
     at a time, as the list_files field may be too slow and/or provide
     too much output.
     """
-    class Meta(object):
+    class Meta:
         model = ExternalFileDirectory
         fields = (
             'pk',
@@ -56,7 +56,7 @@ class DatasetSerializer(AccessControlSerializer, serializers.ModelSerializer):
         required=False
     )
 
-    class Meta(object):
+    class Meta:
         model = Dataset
         fields = (
             'id',

--- a/kive/metadata/forms.py
+++ b/kive/metadata/forms.py
@@ -14,7 +14,7 @@ class UsersAllowedWidget(forms.SelectMultiple):
     """
     A sub-widget of the PermissionsWidget.  This should not be created on its own.
     """
-    class Media(object):
+    class Media:
         css = {
             "all": ("metadata/accumulator.css",)
         }
@@ -25,7 +25,7 @@ class GroupsAllowedWidget(forms.SelectMultiple):
     """
     A sub-widget of the PermissionsWidget.  This should not be created on its own.
     """
-    class Media(object):
+    class Media:
         css = {
             "all": ("metadata/accumulator.css",)
         }

--- a/kive/metadata/models.py
+++ b/kive/metadata/models.py
@@ -4,8 +4,6 @@ metadata.models
 Shipyard data models relating to metadata: Datatypes and their related
 paraphernalia, CompoundDatatypes, etc.
 """
-from __future__ import unicode_literals
-
 from django.db import models, transaction
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.http import Http404

--- a/kive/portal/management/commands/update_test_fixtures.py
+++ b/kive/portal/management/commands/update_test_fixtures.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from datetime import datetime
 import json
 import os

--- a/kive/portal/management/commands/update_test_fixtures.py
+++ b/kive/portal/management/commands/update_test_fixtures.py
@@ -18,7 +18,7 @@ from librarian.models import Dataset
 from portal.management.commands.reset import Command as ResetCommand
 
 
-class FixtureBuilder(object):
+class FixtureBuilder:
     def __init__(self):
         self.next_output_num = self.next_step_num = 1
 

--- a/kive/stopwatch/models.py
+++ b/kive/stopwatch/models.py
@@ -4,8 +4,6 @@ stopwatch.models
 Shipyard abstract class defining anything that has a start- and end-time.
 All such classes should extend Stopwatch.
 """
-from __future__ import unicode_literals
-
 from django.db import models, transaction
 from django.utils import timezone
 from django.core.exceptions import ValidationError

--- a/samplecode/MiCallDemo/micall/core/aln2counts.py
+++ b/samplecode/MiCallDemo/micall/core/aln2counts.py
@@ -64,7 +64,7 @@ logger = miseq_logging.init_logging_console_only(logging.DEBUG)
 MAX_CUTOFF = 'MAX'
 
 
-class SequenceReport(object):
+class SequenceReport:
     """ Hold the data for several reports related to a sample's genetic sequence.
 
     To use a report object, read a group of aligned reads that mapped to a
@@ -519,7 +519,7 @@ class SequenceReport(object):
                                      self.reports[coordinate_name])
 
 
-class SeedAmino(object):
+class SeedAmino:
     """
     Records the frequencies of amino acids at a given position of the
     aligned reads as determined by the consensus sequence.
@@ -564,7 +564,7 @@ class SeedAmino(object):
         return '-' if not consensus else consensus[0][0]
 
 
-class SeedNucleotide(object):
+class SeedNucleotide:
     """
     Records the frequencies of nucleotides at a given position of the
     aligned reads as determined by the consensus sequence.
@@ -634,7 +634,7 @@ class SeedNucleotide(object):
         return consensus
 
 
-class ReportAmino(object):
+class ReportAmino:
     def __init__(self, seed_amino, position):
         """ Create a new instance.
 
@@ -647,7 +647,7 @@ class ReportAmino(object):
         return 'ReportAmino({!r}, {})'.format(self.seed_amino, self.position)
 
 
-class InsertionWriter(object):
+class InsertionWriter:
     def __init__(self, insert_file):
         """ Initialize a writer object.
 

--- a/samplecode/MiCallDemo/micall/core/project_config.py
+++ b/samplecode/MiCallDemo/micall/core/project_config.py
@@ -2,7 +2,7 @@ import json
 import os
 
 
-class ProjectConfig(object):
+class ProjectConfig:
     @classmethod
     def search(cls, project_paths):
         projects = None

--- a/samplecode/MiCallDemo/micall/core/remap.py
+++ b/samplecode/MiCallDemo/micall/core/remap.py
@@ -809,7 +809,7 @@ def map_to_reference(fastq1,
     return unmapped_count
 
 
-class MixedReferenceSplitter(object):
+class MixedReferenceSplitter:
     def __init__(self):
         self.splits = {}
 

--- a/samplecode/MiCallDemo/micall/g2p/pssm_lib.py
+++ b/samplecode/MiCallDemo/micall/g2p/pssm_lib.py
@@ -13,7 +13,7 @@ import gotoh
 from micall.utils.translation import translate
 
 
-class Pssm(object):
+class Pssm:
     def __init__(self, std='g2p', path_to_lookup=None, path_to_matrix=None):
         if std == 'pssm':
             self.std_v3 = 'CTRPNNNTRKGIHIGPGRAFYATGEIIGDIRQAHC'

--- a/samplecode/MiCallDemo/micall/utils/externals.py
+++ b/samplecode/MiCallDemo/micall/utils/externals.py
@@ -4,7 +4,7 @@ import sys
 import re
 
 
-class AssetWrapper(object):
+class AssetWrapper:
     """ Wraps a packaged asset, and finds its path. """
     def __init__(self, path):
         app_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))

--- a/utils/memory_consumer.py
+++ b/utils/memory_consumer.py
@@ -40,7 +40,7 @@ def parse_args():
     return parser.parse_args()
 
 
-class Consumer(object):
+class Consumer:
     def __init__(self,
                  size=1,
                  grow=1,

--- a/utils/memory_watch.py
+++ b/utils/memory_watch.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import unicode_literals
-
 from argparse import ArgumentParser, FileType, ArgumentDefaultsHelpFormatter
 from csv import DictWriter
 import os

--- a/utils/memory_watch.py
+++ b/utils/memory_watch.py
@@ -26,7 +26,7 @@ def parse_args():
     return parser.parse_args()
 
 
-class ZoneInfoScanner(object):
+class ZoneInfoScanner:
     def __init__(self, zone_info):
         self.zone_info = zone_info
 
@@ -63,7 +63,7 @@ class ZoneInfoScanner(object):
                 i += 1
 
 
-class LogWriter(object):
+class LogWriter:
     def __init__(self, log):
         self.log = log
         self.writer = None

--- a/utils/slow_test_report.py
+++ b/utils/slow_test_report.py
@@ -43,7 +43,7 @@ def parseOptions():
     return parser.parse_args()
 
 
-class SlowTestReport(object):
+class SlowTestReport:
     def load(self, report_files, count):
         self.tests = []  # [Test()]
         self.files = []  # [(-time, file_name)]
@@ -70,7 +70,7 @@ class SlowTestReport(object):
         return self
 
 
-class Test(object):
+class Test:
     def __init__(self, testcase):
         self.time = float(testcase.attrib['time'])
         path = testcase.attrib['classname'].split('.')

--- a/utils/test_memory_watch.py
+++ b/utils/test_memory_watch.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from io import StringIO, BytesIO
 from unittest import TestCase
 

--- a/utils/test_speed_plot_loader.py
+++ b/utils/test_speed_plot_loader.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from argparse import Namespace, ArgumentTypeError
 from datetime import datetime, timedelta
 from io import StringIO


### PR DESCRIPTION
This PR cleans up some artifacts in Kive's source code from the Python 2 to Python 3 port.

- Remove unnecessary `from __future__` imports
- Remove inheritance from `object`

Details and links to supporting documentation are in individual commit messages.