### PR TITLE
Add a simple collation script

### DIFF
--- a/samplecode/singularity/concat_csv.py
+++ b/samplecode/singularity/concat_csv.py
@@ -1,0 +1,47 @@
+import argparse
+import csv
+import pathlib
+import typing as ty
+import unittest
+
+PARSER = argparse.ArgumentParser()
+PARSER.add_argument("--inputfiles", nargs="*")
+PARSER.add_argument("outputfile")
+
+
+def write_to_outfile(lines: ty.Iterable[ty.List[str]], outpath: pathlib.Path) -> None:
+    with outpath.open("w") as outf:
+        writer = csv.writer(outf)
+        writer.writerows(lines)
+
+
+def fileinputrows(inputpath: pathlib.Path) -> ty.Iterable[ty.List[str]]:
+    inputname = inputpath.name
+    with inputpath.open() as inputfile:
+        reader = csv.reader(inputfile)
+        for row in reader:
+            yield [inputname] + list(row)
+
+
+def parse_inputrows(inputpaths: ty.List[pathlib.Path]) -> ty.Iterable[ty.List[str]]:
+    for inputpath in inputpaths:
+        yield from fileinputrows(inputpath)
+
+
+def main() -> None:
+    args = PARSER.parse_args()
+    inputfiles = [pathlib.Path(inf) for inf in args.inputfiles]
+    inputrows = parse_inputrows(inputfiles)
+    write_to_outfile(inputrows, pathlib.Path(args.outputfile))
+
+
+class TestConcatCsv(unittest.TestCase):
+    def test_parse_args(self):
+        raw_args = ["--inputfiles", "first.csv", "second.csv", "--", "output.csv"]
+        args = PARSER.parse_args(raw_args)
+        self.assertEqual(args.inputfiles, ["first.csv", "second.csv"])
+        self.assertEqual(args.outputfile, "output.csv")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit adds a simple script for collating CSV files to the
Singularity example code. The purpose of this script is to serve as a
test-bed for the new multi-parameter input arguments; it probably
shouldn't be used to actually collate data in production.

An interesting etymological tidbit: the root of [collation] is a Latin
word meaning "the act of bringing together" which once also meant "a
light supper". This meaning is preserved in French, where
[collation][collation-fr] means "snack".

So anyone who came through French Immersion may be:

1. Transported back to their elementary school days.
2. Disappointed by the content of this app.

[collation]: https://www.etymonline.com/word/collation#etymonline_v_28313
[collation-fr]: https://dictionnaire.lerobert.com/definition/collation