### PR TITLE
Remove shared data directry from dev-env

### DIFF
--- a/dev-env/Vagrantfile
+++ b/dev-env/Vagrantfile
@@ -27,11 +27,6 @@ def add_key_access(vm)
   EOS
 end
 
-# Add a synced folder to emulate the cluster's network drive.
-def add_data_dir(vm)
-  Dir.mkdir("./data") if not Dir.exists?("./data")
-  vm.synced_folder "./data", "/data", mount_options: ["dmode=777", "fmode=664"]
-end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "geerlingguy/centos8"
@@ -47,7 +42,6 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   add_keys(config.vm)
   add_key_access(config.vm)
-  add_data_dir(config.vm)
   config.vm.provision "shell", path: "./install-ansible.sh"
 
   # Add mapped directory with Kive source code


### PR DESCRIPTION
This commit removes the shared Virtualbox directory from the dev-env testing environment. For file-system and permissions reasons, the Kive media root needs to be in the VM's filesystem (not a shared directory) for this environment, and data can be persisted between VMs using the default '/vagrant' directory. The shared directory is only a source of confusion. 😖 