### PR TITLE
Dev env fix

### DIFF
--- a/dev-env/ansible.cfg
+++ b/dev-env/ansible.cfg
@@ -6,3 +6,4 @@
 inventory = ./inventory.ini
 interpreter_python = /usr/bin/python3.6
 roles_path = ../roles
+remote_tmp = /tmp/

--- a/dev-env/install-ansible.sh
+++ b/dev-env/install-ansible.sh
@@ -13,4 +13,6 @@ dnf install -q -y python3
 python3 -m pip install -r /vagrant/requirements.txt
 
 # Add host keys to `known_hosts`
+mkdir -p ~/.ssh/
+touch ~/.ssh/known_hosts
 ssh-keyscan head >> ~/.ssh/known_hosts

--- a/roles/kive_node/tasks/main.yml
+++ b/roles/kive_node/tasks/main.yml
@@ -25,7 +25,7 @@
     - /etc/kive/
     - /var/kive/
     - /var/log/kive/
-    - /data/kive/media_root/
+    - "{{ kive_media_root }}"
   file:
     path: "{{ item }}"
     state: directory

--- a/roles/kive_server/tasks/main.yml
+++ b/roles/kive_server/tasks/main.yml
@@ -105,6 +105,12 @@
             users: kive
             source: "127.0.0.1/32"
             method: "scram-sha-256"
+    - name: restart database service
+      become: true
+      become_user: root
+      systemd:
+        name: "postgresql-12"
+        state: restarted
 
 
 - name: kive installation


### PR DESCRIPTION
This commit fixes a number of issues with the Kive `dev-env` environment by:

- Adjusting the location where Ansible puts temporary files (it should be globally writable so that Ansible can become the `kive` user and still access it)
- Restart Postgres after adjusting its configuration
- Make sure the root user has a `.ssh` directory (so that the VM's key can be added to `known_hosts`)