### PR TITLE
Data import and export playbooks for dev-env

### DIFF
--- a/dev-env/.gitignore
+++ b/dev-env/.gitignore
@@ -1,2 +1,3 @@
 .vagrant/
 data/
+*.tar

--- a/dev-env/dev_env_vars.yml
+++ b/dev-env/dev_env_vars.yml
@@ -14,7 +14,7 @@ kive_venv: /opt/venv_kive
 kive_db_name: kive
 kive_db_user: kive
 kive_db_host: head
-kive_media_root: /tmp/kive/media_root
+kive_media_root: /var/kive/media_root
 kive_static_root: /var/www/html/kive/static
 kive_slurm_path: "{{ kive_venv }}/bin"
 kive_root: /usr/local/share/Kive

--- a/dev-env/export-data.yml
+++ b/dev-env/export-data.yml
@@ -1,0 +1,37 @@
+- hosts: head
+  vars_files:
+    - dev_env_vars.yml
+  vars:
+    backup_dir: "/tmp/kivebackup"
+    dbdump_file: "{{backup_dir}}/dbdump.sql"
+    archive_file: "/tmp/kivebackup.tar"
+  tasks:
+    - name: create save data directory
+      file:
+        path: "{{ backup_dir }}"
+        state: directory
+    - name: dump database contents
+      become: true
+      postgresql_db:
+        state: dump
+        name: kive
+        login_user: kive
+        login_password: "{{ kive_db_password }}"
+        target: "{{dbdump_file}}"
+        target_opts: "--create --clean --if-exists"  # only dump tables from the 'public' schema
+    - name: create backup archive
+      become: true
+      archive:
+        dest: "{{ archive_file }}"
+        format: tar
+        path:
+          - "{{ kive_media_root }}/*"
+          - "{{ dbdump_file}}"
+        exclude_path:
+          - "{{kive_media_root}}/ContainerRuns"
+          - "{{kive_media_root}}/Sandboxes"
+    - name: download data
+      fetch:
+        src: "{{archive_file}}"
+        dest: "./kivebackup.tar"
+        flat: true

--- a/dev-env/export-data.yml
+++ b/dev-env/export-data.yml
@@ -29,9 +29,12 @@
           - "{{ dbdump_file}}"
         exclude_path:
           - "{{kive_media_root}}/ContainerRuns"
-          - "{{kive_media_root}}/Sandboxes"
     - name: download data
       fetch:
         src: "{{archive_file}}"
         dest: "./kivebackup.tar"
         flat: true
+    - name: clean up
+        file:
+          path: "{{ backup_dir }}"
+          state: absent

--- a/dev-env/import-data.yml
+++ b/dev-env/import-data.yml
@@ -27,12 +27,12 @@
         name: postgres
         owner: kive
         state: restore
-        target: "{{backup_dir}}/{{ dbdump_file }}"
+        target: "{{backup_dir}}{{ dbdump_file }}"
         target_opts: "--set ON_ERROR_STOP=on"
     - name: restore media root
       become: true
       copy:
-        src: "{{ backup_dir }}/media_root"
+        src: "{{ backup_dir }}{{ kive_media_root }}/"
         dest: "{{ kive_media_root }}"
         remote_src: true
         owner: kive

--- a/dev-env/import-data.yml
+++ b/dev-env/import-data.yml
@@ -1,0 +1,39 @@
+- hosts: head
+  vars_files:
+    - dev_env_vars.yml
+  vars:
+    backup_dir: "/tmp/kivebackup/"
+    dbdump_file: "{{backup_dir}}/dbdump.sql"
+    archive_file: "/tmp/kivebackup.tar"
+  tasks:
+    - name: delete existing backup
+      become: true
+      file:
+        path: "{{ backup_dir }}"
+        state: absent
+    - name: create import directory
+      file:
+        path: "{{ backup_dir }}"
+        state: directory
+        mode: "777"
+    - name: upload and extract archive
+      unarchive:
+        dest: "{{ backup_dir }}"
+        src: "./kivebackup.tar"
+    - name: restore database backup
+      become: true
+      become_user: postgres
+      postgresql_db:
+        name: postgres
+        owner: kive
+        state: restore
+        target: "{{backup_dir}}/{{ dbdump_file }}"
+        target_opts: "--set ON_ERROR_STOP=on"
+    - name: restore media root
+      become: true
+      copy:
+        src: "{{ backup_dir }}/media_root"
+        dest: "{{ kive_media_root }}"
+        remote_src: true
+        owner: kive
+        group: kive

--- a/dev-env/import-data.yml
+++ b/dev-env/import-data.yml
@@ -6,34 +6,55 @@
     dbdump_file: "{{backup_dir}}/dbdump.sql"
     archive_file: "/tmp/kivebackup.tar"
   tasks:
-    - name: delete existing backup
-      become: true
-      file:
-        path: "{{ backup_dir }}"
-        state: absent
-    - name: create import directory
-      file:
-        path: "{{ backup_dir }}"
-        state: directory
-        mode: "777"
-    - name: upload and extract archive
-      unarchive:
-        dest: "{{ backup_dir }}"
-        src: "./kivebackup.tar"
-    - name: restore database backup
-      become: true
-      become_user: postgres
-      postgresql_db:
-        name: postgres
-        owner: kive
-        state: restore
-        target: "{{backup_dir}}{{ dbdump_file }}"
-        target_opts: "--set ON_ERROR_STOP=on"
-    - name: restore media root
-      become: true
-      copy:
-        src: "{{ backup_dir }}{{ kive_media_root }}/"
-        dest: "{{ kive_media_root }}"
-        remote_src: true
-        owner: kive
-        group: kive
+    - name: confirmation prompt
+      register: confirm_delete
+      pause:
+        prompt: |-
+
+          ██╗    ██╗ █████╗ ██████╗ ███╗   ██╗██╗███╗   ██╗ ██████╗ ██╗
+          ██║    ██║██╔══██╗██╔══██╗████╗  ██║██║████╗  ██║██╔════╝ ██║
+          ██║ █╗ ██║███████║██████╔╝██╔██╗ ██║██║██╔██╗ ██║██║  ███╗██║
+          ██║███╗██║██╔══██║██╔══██╗██║╚██╗██║██║██║╚██╗██║██║   ██║╚═╝
+          ╚███╔███╔╝██║  ██║██║  ██║██║ ╚████║██║██║ ╚████║╚██████╔╝██╗
+          ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═══╝ ╚═════╝ ╚═╝
+
+          This playbook will DELETE EVERYTHING that's currently in the database.
+
+          HOST: {{ inventory_hostname }}
+
+          Push Enter to cancel.
+
+          If you understand and wish to continue, type "yes" and push Enter
+    - name: perform backup
+      when: confirm_delete.user_input == "yes"
+      block:
+        - name: create import directory
+          file:
+            path: "{{ backup_dir }}"
+            state: directory
+            mode: "777"
+        - name: upload and extract archive
+          unarchive:
+            dest: "{{ backup_dir }}"
+            src: "./kivebackup.tar"
+        - name: restore database backup
+          become: true
+          become_user: postgres
+          postgresql_db:
+            name: postgres
+            owner: kive
+            state: restore
+            target: "{{backup_dir}}{{ dbdump_file }}"
+            target_opts: "--set ON_ERROR_STOP=on"
+        - name: restore media root
+          become: true
+          copy:
+            src: "{{ backup_dir }}{{ kive_media_root }}/"
+            dest: "{{ kive_media_root }}"
+            remote_src: true
+            owner: kive
+            group: kive
+        - name: clean up
+          file:
+            path: "{{ backup_dir }}"
+            state: absent

--- a/dev-env/install-ansible.sh
+++ b/dev-env/install-ansible.sh
@@ -15,3 +15,6 @@ python3 -m pip install -r /vagrant/requirements.txt
 # Add host keys to `known_hosts`
 mkdir -p ~/.ssh/
 ssh-keyscan head >> ~/.ssh/known_hosts
+
+# Add ANSIBLE_CONFIG to environment
+echo "export ANSIBLE_CONFIG='/usr/local/share/Kive/dev-env/ansible.cfg'" >> /home/vagrant/.bashrc

--- a/roles/kive_server/tasks/main.yml
+++ b/roles/kive_server/tasks/main.yml
@@ -35,6 +35,8 @@
           Environment=KIVE_SLURM_PATH="{{ kive_slurm_path }}"
           Environment=KIVE_SECRET_KEY="{{kive_server_secret_key}}"
           Environment=KIVE_ALLOWED_HOSTS="{{ kive_allowed_hosts | to_json }}"
+          Environment=APACHE_RUN_USER=kive
+          Environment=APACHE_RUN_GROUP=kive
     - name: update httpd.conf
       loop:
         - from: "Listen 80$"


### PR DESCRIPTION
This PR adds two playbooks to the `dev-env` directory for importing and exporting dev data.

The `export-data.yml` playbook puts a database dump and a copy of the Kive MEDIA_ROOT in a TAR file and then downloads it.

The `import-data.yml` playbook uploads a TAR file created with the export playbook and applies it to the `dev-env` (loading the database dump and restoring the files from MEDIA_ROOT).

The import is destructive (i.e. any data in the database will be dropped before the import happens), so it is probably not suitable for use in a production environment.

Both playbooks can be run from the `dev-env` directory in the project's Vagrant box, which results in the archive file being stored in a mapped directory. Both playbooks can also be run from a separate host if Ansible (i.e. an inventory is supplied to replace the one in `dev-env`).