### PR TITLE
Pin singularity version

### DIFF
--- a/roles/singularity_node/tasks/main.yml
+++ b/roles/singularity_node/tasks/main.yml
@@ -5,4 +5,5 @@
 - name: install singularity
   become: true
   dnf:
-    name: singularity
+    name: singularity-3.6.*  # accept bugfix releases
+    state: present


### PR DESCRIPTION
This commit adds a version specification (3.6.*) in the Ansible role
that installs Singularity, with the objective of making the setup
process more repeatable.