### PR TITLE
Skip empty HTTP options

### DIFF
--- a/roles/kive_server/tasks/main.yml
+++ b/roles/kive_server/tasks/main.yml
@@ -34,7 +34,7 @@
           Environment=KIVE_STATIC_ROOT="{{ kive_static_root }}"
           Environment=KIVE_SLURM_PATH="{{ kive_slurm_path }}"
           Environment=KIVE_SECRET_KEY="{{kive_server_secret_key}}"
-          Environment=KIVE_ALLOWED_HOSTS="{{ kive_allowed_hosts | to_json }}"
+          Environment=KIVE_ALLOWED_HOSTS={{ kive_allowed_hosts | to_json }}
           Environment=APACHE_RUN_USER=kive
           Environment=APACHE_RUN_GROUP=kive
     - name: update httpd.conf

--- a/roles/kive_server/tasks/main.yml
+++ b/roles/kive_server/tasks/main.yml
@@ -38,6 +38,7 @@
           Environment=APACHE_RUN_USER=kive
           Environment=APACHE_RUN_GROUP=kive
     - name: update httpd.conf
+      when: item  # don't set empty variables
       loop:
         - from: "Listen 80$"
           to: "Listen {{ kive_listen_port }}"


### PR DESCRIPTION
This lets us leave out options and handle them manually on the production server, which has slightly different configuration needs because it uses TLS.