### PR TITLE
Parametrize the slurmctld head node configuration

### DIFF
--- a/dev-env/dev_env_vars.yml
+++ b/dev-env/dev_env_vars.yml
@@ -24,6 +24,7 @@ kive_httpd_group: kive
 # - package variables
 slurmbuilddir: "/root"
 # - Nodes to tell Slurm about (with hostname and memory in MB)
+slurmctlnode: head
 slurmnodes:
     - name: head
       memory: "7000"

--- a/roles/slurm_node/templates/slurm.conf.j2
+++ b/roles/slurm_node/templates/slurm.conf.j2
@@ -1,4 +1,4 @@
-ControlMachine=head
+ControlMachine={{slurmctlnode}}
 #ControlAddr=
 #BackupController=
 #BackupAddr=
@@ -116,7 +116,7 @@ SelectTypeParameters=CR_CPU_Memory
 #
 # LOGGING AND ACCOUNTING
 #AccountingStorageEnforce=0
-AccountingStorageHost=head
+AccountingStorageHost={{slurmctlnode}}
 #AccountingStorageLoc=/var/log/slurm/accounting
 #AccountingStoragePass=
 AccountingStoragePort=6819


### PR DESCRIPTION
This commit sets the head node and account storage database node in the
`slurmctld` configuration file (`slurm.conf`) from an environment
variable. Previously, it was hard-coded.

This configuration is necessary because we want to use different head
nodes in different environments (`head` in the `dev-env`, `bulbasaur` or
`octomore` on the live clusters).